### PR TITLE
home画面でクエストを最大3個表示するように変更

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -53,8 +53,8 @@ export default function HomeScreen() {
     setIsRefreshing(false);
   };
 
-  // 現在進行中のクエスト（未完了の最初のクエスト）
-  const currentQuest = quests.find((q) => !q.completed);
+  // 現在進行中のクエスト（未完了のクエストを最大3個表示）
+  const currentQuests = quests.filter((q) => !q.completed).slice(0, 3);
   const completedCount = quests.filter((q) => q.completed).length;
   const progressPercent = quests.length > 0 ? (completedCount / quests.length) * 100 : 0;
 
@@ -301,95 +301,99 @@ export default function HomeScreen() {
               読み込み中...
             </Text>
           </View>
-        ) : currentQuest ? (
-          <Link href="/(tabs)/quests" asChild>
-            <Pressable
-              style={{
-                backgroundColor: "rgba(255,255,255,0.95)",
-                padding: 16,
-                borderRadius: 24,
-                flexDirection: "row",
-                alignItems: "center",
-                gap: 14,
-                borderWidth: 1,
-                borderColor: "rgba(255,255,255,0.9)",
-                boxShadow: "0 12px 24px rgba(168, 223, 142, 0.2)",
-                borderCurve: "continuous",
-              }}
-            >
-              <View
-                style={{
-                  height: 56,
-                  width: 56,
-                  borderRadius: 18,
-                  backgroundColor: "rgba(168, 223, 142, 0.2)",
-                  alignItems: "center",
-                  justifyContent: "center",
-                }}
-              >
-                <IconSymbol name="wind" size={28} color="#A8DF8E" />
-              </View>
-              <View style={{ flex: 1 }}>
-                <Text
-                  selectable
+        ) : currentQuests.length > 0 ? (
+          <View style={{ gap: 12 }}>
+            {currentQuests.map((quest, index) => (
+              <Link href="/(tabs)/quests" asChild key={quest.id}>
+                <Pressable
                   style={{
-                    fontSize: 10,
-                    fontWeight: "700",
-                    color: "#A8DF8E",
-                    letterSpacing: 0.5,
-                    fontFamily: Fonts.rounded,
-                  }}
-                >
-                  現在のクエスト ({completedCount}/{quests.length})
-                </Text>
-                <Text
-                  selectable
-                  style={{
-                    fontSize: 16,
-                    fontWeight: "700",
-                    color: "#3A4D39",
-                    marginTop: 4,
-                    fontFamily: Fonts.rounded,
-                  }}
-                  numberOfLines={1}
-                >
-                  {currentQuest.title}
-                </Text>
-                <View
-                  style={{
-                    marginTop: 10,
-                    height: 8,
-                    borderRadius: 999,
-                    backgroundColor: "rgba(168, 223, 142, 0.15)",
-                    overflow: "hidden",
+                    backgroundColor: "rgba(255,255,255,0.95)",
+                    padding: 16,
+                    borderRadius: 24,
+                    flexDirection: "row",
+                    alignItems: "center",
+                    gap: 14,
+                    borderWidth: 1,
+                    borderColor: "rgba(255,255,255,0.9)",
+                    boxShadow: "0 12px 24px rgba(168, 223, 142, 0.2)",
+                    borderCurve: "continuous",
                   }}
                 >
                   <View
                     style={{
-                      width: `${progressPercent}%`,
-                      height: "100%",
+                      height: 56,
+                      width: 56,
+                      borderRadius: 18,
+                      backgroundColor: "rgba(168, 223, 142, 0.2)",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    <IconSymbol name="wind" size={28} color="#A8DF8E" />
+                  </View>
+                  <View style={{ flex: 1 }}>
+                    <Text
+                      selectable
+                      style={{
+                        fontSize: 10,
+                        fontWeight: "700",
+                        color: "#A8DF8E",
+                        letterSpacing: 0.5,
+                        fontFamily: Fonts.rounded,
+                      }}
+                    >
+                      クエスト {index + 1}/{currentQuests.length}
+                    </Text>
+                    <Text
+                      selectable
+                      style={{
+                        fontSize: 16,
+                        fontWeight: "700",
+                        color: "#3A4D39",
+                        marginTop: 4,
+                        fontFamily: Fonts.rounded,
+                      }}
+                      numberOfLines={1}
+                    >
+                      {quest.title}
+                    </Text>
+                    <View
+                      style={{
+                        marginTop: 10,
+                        height: 8,
+                        borderRadius: 999,
+                        backgroundColor: "rgba(168, 223, 142, 0.15)",
+                        overflow: "hidden",
+                      }}
+                    >
+                      <View
+                        style={{
+                          width: `${progressPercent}%`,
+                          height: "100%",
+                          borderRadius: 999,
+                          backgroundColor: "#A8DF8E",
+                          boxShadow: "0 0 10px rgba(168, 223, 142, 0.6)",
+                        }}
+                      />
+                    </View>
+                  </View>
+                  <View
+                    style={{
+                      height: 44,
+                      width: 44,
                       borderRadius: 999,
                       backgroundColor: "#A8DF8E",
-                      boxShadow: "0 0 10px rgba(168, 223, 142, 0.6)",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      boxShadow: "0 8px 16px rgba(168, 223, 142, 0.3)",
                     }}
-                  />
-                </View>
-              </View>
-              <View
-                style={{
-                  height: 44,
-                  width: 44,
-                  borderRadius: 999,
-                  backgroundColor: "#A8DF8E",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  boxShadow: "0 8px 16px rgba(168, 223, 142, 0.3)",
-                }}
-              >
-                <IconSymbol name="chevron.right" size={18} color="#FFFFFF" />
-              </View>
-            </Pressable>
-          </Link>
+                  >
+                    <IconSymbol name="chevron.right" size={18} color="#FFFFFF" />
+                  </View>
+                </Pressable>
+              </Link>
+            ))}
+          </View>
         ) : quests.length > 0 ? (
           <View
             style={{


### PR DESCRIPTION
## 変更内容

home画面で表示されるクエストを1個から最大3個に変更しました。

### 変更詳細
- 未完了のクエストを最大3個まで表示
- 複数クエストをカード形式でリスト表示
- 各クエストカードに進捗状況を表示

### 技術的な変更
- `currentQuest` 変数を `currentQuests` 配列に変更
- `.find()` を `.filter().slice(0, 3)` に変更
- クエスト表示部分を `.map()` で繰り返し処理

## スクリーンショット
UI変更あり（home画面のクエスト表示部分）