### PR TITLE
feat: iOS通知アイコンの設定を追加

### DIFF
--- a/app.json
+++ b/app.json
@@ -50,6 +50,13 @@
             "backgroundColor": "#000000"
           }
         }
+      ],
+      [
+        "expo-notifications",
+        {
+          "icon": "./assets/images/icon.png",
+          "color": "#ffffff"
+        }
       ]
     ],
     "experiments": {


### PR DESCRIPTION
## 概要

iOSでアプリケーションのiconがnotifyのiconとして使用する設定を追加しました。

## 変更内容

- expo-notificationsプラグインにiOS用のアイコン設定を追加
- アプリケーションのicon.pngを通知アイコンとして使用するように設定
- 通知アイコンの背景色を白色に設定

## 技術的な詳細

- `app.json`の`plugins`セクションに`expo-notifications`の設定を追加
- iOSではアプリケーションのiconがnotifyのiconとして使用されます

## テスト内容

- 設定変更のみのため、ビルド時の動作確認が必要です