### PR TITLE
feat: デバッグモードで夜アンケート未回答でもすれ違いを表示できる機能を追加

### DIFF
--- a/app/(tabs)/log.tsx
+++ b/app/(tabs)/log.tsx
@@ -1,5 +1,7 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useFocusEffect } from '@react-navigation/native';
 import { Image } from 'expo-image';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native';
 
 import { GrassBackground } from '@/components/grass-background';
@@ -8,6 +10,17 @@ import { Fonts } from '@/constants/theme';
 import { useNightQuestionnaire } from '@/hooks/use-night-questionnaire';
 import { getMyEncounters, type EncounterWithQuests } from '@/lib/api';
 
+const DEBUG_SHOW_ENCOUNTERS_WITHOUT_NIGHT_KEY = 'debug:showEncountersWithoutNight';
+
+const getDebugShowEncountersWithoutNight = async (): Promise<boolean> => {
+  try {
+    const raw = await AsyncStorage.getItem(DEBUG_SHOW_ENCOUNTERS_WITHOUT_NIGHT_KEY);
+    return raw === 'true';
+  } catch {
+    return false;
+  }
+};
+
 // デフォルトアプリアイコンのURL
 const DEFAULT_AVATAR = require('@/assets/images/icon.png');
 
@@ -15,10 +28,23 @@ export default function LogScreen() {
   const { isCompleted, isLoading: isLoadingQuestionnaire } = useNightQuestionnaire();
   const [encounters, setEncounters] = useState<EncounterWithQuests[]>([]);
   const [isLoadingEncounters, setIsLoadingEncounters] = useState(false);
+  const [debugMode, setDebugMode] = useState(false);
+
+  // デバッグモードの状態を読み込む（画面がフォーカスされるたびに再読み込み）
+  useFocusEffect(
+    useCallback(() => {
+      const loadDebugMode = async () => {
+        const isDebugMode = await getDebugShowEncountersWithoutNight();
+        setDebugMode(isDebugMode);
+      };
+      loadDebugMode();
+    }, [])
+  );
 
   // すれ違い情報を取得
   useEffect(() => {
-    if (isCompleted && !isLoadingQuestionnaire) {
+    // デバッグモードがON、または夜アンケートが完了している場合に取得
+    if ((debugMode || isCompleted) && !isLoadingQuestionnaire) {
       const loadEncounters = async () => {
         setIsLoadingEncounters(true);
         try {
@@ -39,9 +65,10 @@ export default function LogScreen() {
 
       loadEncounters();
     }
-  }, [isCompleted, isLoadingQuestionnaire]);
-  // すれ違いが未ロック（夜アンケート未回答）の場合
-  if (!isCompleted) {
+  }, [isCompleted, isLoadingQuestionnaire, debugMode]);
+
+  // すれ違いが未ロック（夜アンケート未回答）かつデバッグモードがOFFの場合
+  if (!isCompleted && !debugMode) {
     return (
       <GrassBackground>
         <ScrollView

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,3 +1,4 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Notifications from "expo-notifications";
 import { useRouter } from "expo-router";
 import React, { useEffect, useState } from "react";
@@ -9,35 +10,77 @@ import { Fonts } from "@/constants/theme";
 import { useAuth } from "@/hooks/use-auth";
 
 const DEBUG_SKIP_QUESTIONNAIRE_LIMIT_KEY = "debug:skipQuestionnaireLimit";
+const DEBUG_SHOW_ENCOUNTERS_WITHOUT_NIGHT_KEY = "debug:showEncountersWithoutNight";
 
-const getDebugSkipLimit = (): boolean => {
-  if (typeof localStorage === "undefined") return false;
-  const raw = localStorage.getItem(DEBUG_SKIP_QUESTIONNAIRE_LIMIT_KEY);
-  return raw === "true";
+const getDebugSkipLimit = async (): Promise<boolean> => {
+  try {
+    const raw = await AsyncStorage.getItem(DEBUG_SKIP_QUESTIONNAIRE_LIMIT_KEY);
+    return raw === "true";
+  } catch {
+    return false;
+  }
 };
 
-const setDebugSkipLimit = (value: boolean) => {
-  if (typeof localStorage === "undefined") return;
-  localStorage.setItem(DEBUG_SKIP_QUESTIONNAIRE_LIMIT_KEY, String(value));
+const setDebugSkipLimit = async (value: boolean) => {
+  try {
+    await AsyncStorage.setItem(DEBUG_SKIP_QUESTIONNAIRE_LIMIT_KEY, String(value));
+  } catch {
+    // エラーは無視
+  }
+};
+
+const getDebugShowEncountersWithoutNight = async (): Promise<boolean> => {
+  try {
+    const raw = await AsyncStorage.getItem(DEBUG_SHOW_ENCOUNTERS_WITHOUT_NIGHT_KEY);
+    return raw === "true";
+  } catch {
+    return false;
+  }
+};
+
+const setDebugShowEncountersWithoutNight = async (value: boolean) => {
+  try {
+    await AsyncStorage.setItem(DEBUG_SHOW_ENCOUNTERS_WITHOUT_NIGHT_KEY, String(value));
+  } catch {
+    // エラーは無視
+  }
 };
 
 export default function SettingsScreen() {
   const router = useRouter();
   const { signOut, session } = useAuth();
   const [skipQuestionnaireLimit, setSkipQuestionnaireLimit] = useState(false);
+  const [showEncountersWithoutNight, setShowEncountersWithoutNight] = useState(false);
 
   useEffect(() => {
-    setSkipQuestionnaireLimit(getDebugSkipLimit());
+    const loadDebugSettings = async () => {
+      const skipLimit = await getDebugSkipLimit();
+      const showEncounters = await getDebugShowEncountersWithoutNight();
+      setSkipQuestionnaireLimit(skipLimit);
+      setShowEncountersWithoutNight(showEncounters);
+    };
+    loadDebugSettings();
   }, []);
 
-  const handleToggleSkipLimit = (value: boolean) => {
-    setDebugSkipLimit(value);
+  const handleToggleSkipLimit = async (value: boolean) => {
+    await setDebugSkipLimit(value);
     setSkipQuestionnaireLimit(value);
     Alert.alert(
       value ? "有効化" : "無効化",
       value
         ? "アンケートの回答制限がスキップされました"
         : "アンケートの回答制限が有効になりました"
+    );
+  };
+
+  const handleToggleShowEncounters = async (value: boolean) => {
+    await setDebugShowEncountersWithoutNight(value);
+    setShowEncountersWithoutNight(value);
+    Alert.alert(
+      value ? "有効化" : "無効化",
+      value
+        ? "夜のアンケートを答えなくてもすれ違いを見れるようになりました"
+        : "夜のアンケート完了が必要になりました"
     );
   };
 
@@ -311,6 +354,51 @@ export default function SettingsScreen() {
               onValueChange={handleToggleSkipLimit}
               trackColor={{ false: "#E5E5E5", true: "rgba(168, 223, 142, 0.5)" }}
               thumbColor={skipQuestionnaireLimit ? "#A8DF8E" : "#F4F3F4"}
+            />
+          </View>
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "space-between",
+              backgroundColor: "rgba(255, 170, 184, 0.1)",
+              borderRadius: 12,
+              paddingVertical: 12,
+              paddingHorizontal: 14,
+            }}
+          >
+            <View style={{ flexDirection: "row", alignItems: "center", gap: 8, flex: 1 }}>
+              <IconSymbol name="eye.fill" size={16} color="#FFAAB8" />
+              <View style={{ flex: 1 }}>
+                <Text
+                  selectable
+                  style={{
+                    fontSize: 12,
+                    fontWeight: "700",
+                    color: "#3A4D39",
+                    fontFamily: Fonts.rounded,
+                  }}
+                >
+                  すれ違いをデバッグモードで見る
+                </Text>
+                <Text
+                  selectable
+                  style={{
+                    fontSize: 10,
+                    color: "#718268",
+                    fontFamily: Fonts.rounded,
+                    marginTop: 2,
+                  }}
+                >
+                  デバッグ用: 夜のアンケート未回答でもすれ違いを表示
+                </Text>
+              </View>
+            </View>
+            <Switch
+              value={showEncountersWithoutNight}
+              onValueChange={handleToggleShowEncounters}
+              trackColor={{ false: "#E5E5E5", true: "rgba(255, 170, 184, 0.5)" }}
+              thumbColor={showEncountersWithoutNight ? "#FFAAB8" : "#F4F3F4"}
             />
           </View>
         </View>


### PR DESCRIPTION
## 概要

デバッグ用に、夜のアンケートを回答していなくてもすれ違い情報を表示できる機能を追加しました。また、設定画面のデバッグ機能をlocalStorageからAsyncStorageへ移行し、React Native環境に対応しました。

## 変更内容

- 設定画面に「すれ違いをデバッグモードで見る」スイッチを追加
- デバッグモードON時は夜アンケート未回答でもすれ違い情報を取得・表示できるように変更
- localStorageからAsyncStorageへの移行（React Native対応）
- デバッグ設定の読み込みを非同期化し、画面フォーカス時に再読み込みするように変更

## 技術的な詳細

- AsyncStorageを使用してデバッグ設定を永続化
- useFocusEffectを使用して設定画面から戻った際に設定を再読み込み
- すれ違い情報の取得条件にデバッグモードの状態を追加

## テスト内容

- 設定画面でデバッグモードをON/OFFできることを確認
- デバッグモードON時、夜アンケート未回答でもすれ違い画面が表示されることを確認
- デバッグモードOFF時、従来通り夜アンケート完了が必要なことを確認
- 設定の永続化が正しく動作することを確認