### PR TITLE
feat: プロフィール画像(avatar_url)をURLのみで表示・保存

### DIFF
--- a/app/(tabs)/log.tsx
+++ b/app/(tabs)/log.tsx
@@ -1,15 +1,12 @@
-import { Image } from 'expo-image';
 import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native';
 
 import { GrassBackground } from '@/components/grass-background';
+import { AvatarImage } from '@/components/ui/avatar-image';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Fonts } from '@/constants/theme';
 import { useNightQuestionnaire } from '@/hooks/use-night-questionnaire';
 import { getMyEncounters, type EncounterWithQuests } from '@/lib/api';
-
-// デフォルトアプリアイコンのURL
-const DEFAULT_AVATAR = require('@/assets/images/icon.png');
 
 export default function LogScreen() {
   const { isCompleted, isLoading: isLoadingQuestionnaire } = useNightQuestionnaire();
@@ -208,9 +205,6 @@ export default function LogScreen() {
         {!isLoadingEncounters && encounters.length > 0 && (
           <View style={{ paddingHorizontal: 16, gap: 14 }}>
             {encounters.map((encounter) => {
-              const avatarSource = encounter.other_user_avatar
-                ? { uri: encounter.other_user_avatar }
-                : DEFAULT_AVATAR;
               const displayName = encounter.other_user_name || '旅の仲間';
 
               // 今日達成したクエストを表示（最大3件）
@@ -241,20 +235,10 @@ export default function LogScreen() {
                     borderCurve: 'continuous',
                   }}>
                   <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12, flex: 1 }}>
-                    <View
-                      style={{
-                        height: 56,
-                        width: 56,
-                        borderRadius: 999,
-                        backgroundColor: '#F0FFDF',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        overflow: 'hidden',
-                        borderWidth: 2,
-                        borderColor: '#F0FFDF',
-                      }}>
-                      <Image source={avatarSource} style={{ width: 56, height: 56 }} />
-                    </View>
+                    <AvatarImage
+                      avatarUrl={encounter.other_user_avatar}
+                      size={56}
+                    />
                     <View style={{ flex: 1 }}>
                       <Text
                         selectable

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,12 +1,14 @@
 import * as Notifications from "expo-notifications";
 import { useRouter } from "expo-router";
-import React, { useEffect, useState } from "react";
-import { Alert, Pressable, ScrollView, Switch, Text, View } from "react-native";
+import React, { useCallback, useEffect, useState } from "react";
+import { Alert, Pressable, ScrollView, Switch, Text, TextInput, View } from "react-native";
 
 import { GrassBackground } from "@/components/grass-background";
+import { AvatarImage } from "@/components/ui/avatar-image";
 import { IconSymbol } from "@/components/ui/icon-symbol";
 import { Fonts } from "@/constants/theme";
 import { useAuth } from "@/hooks/use-auth";
+import { getMyProfile, updateMyAvatar } from "@/lib/api";
 
 const DEBUG_SKIP_QUESTIONNAIRE_LIMIT_KEY = "debug:skipQuestionnaireLimit";
 
@@ -25,10 +27,27 @@ export default function SettingsScreen() {
   const router = useRouter();
   const { signOut, session } = useAuth();
   const [skipQuestionnaireLimit, setSkipQuestionnaireLimit] = useState(false);
+  const [profileAvatarUrl, setProfileAvatarUrl] = useState<string | null>(null);
+  const [avatarUrlInput, setAvatarUrlInput] = useState("");
+  const [isSavingAvatar, setIsSavingAvatar] = useState(false);
+
+  const loadProfile = useCallback(async () => {
+    const profile = await getMyProfile();
+    if (profile) {
+      setProfileAvatarUrl(profile.avatar_url ?? null);
+      setAvatarUrlInput(profile.avatar_url?.trim() ?? "");
+    }
+  }, []);
 
   useEffect(() => {
     setSkipQuestionnaireLimit(getDebugSkipLimit());
   }, []);
+
+  useEffect(() => {
+    if (session?.user) {
+      loadProfile();
+    }
+  }, [session?.user, loadProfile]);
 
   const handleToggleSkipLimit = (value: boolean) => {
     setDebugSkipLimit(value);
@@ -62,6 +81,18 @@ export default function SettingsScreen() {
       });
     } catch {
       Alert.alert("通知エラー", "通知の送信に失敗しました");
+    }
+  };
+
+  const handleSaveAvatarUrl = async () => {
+    setIsSavingAvatar(true);
+    try {
+      await updateMyAvatar(avatarUrlInput);
+      await loadProfile();
+    } catch (err) {
+      Alert.alert("エラー", "アバターURLの保存に失敗しました");
+    } finally {
+      setIsSavingAvatar(false);
     }
   };
 
@@ -103,18 +134,7 @@ export default function SettingsScreen() {
           }}
         >
           <View style={{ flexDirection: "row", alignItems: "center", gap: 14 }}>
-            <View
-              style={{
-                width: 48,
-                height: 48,
-                borderRadius: 999,
-                backgroundColor: "rgba(168, 223, 142, 0.2)",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              <IconSymbol name="person.fill" size={22} color="#A8DF8E" />
-            </View>
+            <AvatarImage avatarUrl={profileAvatarUrl} size={48} />
             <View style={{ flex: 1, minWidth: 0, justifyContent: "center", gap: 2 }}>
               <Text
                 selectable
@@ -159,6 +179,61 @@ export default function SettingsScreen() {
                 </>
               )}
             </View>
+          </View>
+
+          {/* アバターURL入力 */}
+          <View style={{ marginTop: 16, gap: 8 }}>
+            <Text
+              selectable
+              style={{
+                fontSize: 12,
+                fontWeight: "700",
+                color: "#718268",
+                fontFamily: Fonts.rounded,
+              }}
+            >
+              アバターURL
+            </Text>
+            <TextInput
+              placeholder="https://..."
+              placeholderTextColor="rgba(113, 130, 104, 0.5)"
+              value={avatarUrlInput}
+              onChangeText={setAvatarUrlInput}
+              style={{
+                height: 44,
+                borderRadius: 12,
+                backgroundColor: "rgba(168, 223, 142, 0.1)",
+                paddingHorizontal: 14,
+                fontSize: 13,
+                color: "#141712",
+                fontFamily: Fonts.rounded,
+              }}
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+            <Pressable
+              onPress={handleSaveAvatarUrl}
+              disabled={isSavingAvatar}
+              style={{
+                backgroundColor: "rgba(168, 223, 142, 0.3)",
+                borderRadius: 12,
+                paddingVertical: 10,
+                alignItems: "center",
+                opacity: isSavingAvatar ? 0.7 : 1,
+              }}
+            >
+              <Text
+                selectable
+                style={{
+                  fontSize: 13,
+                  fontWeight: "700",
+                  color: "#3A4D39",
+                  fontFamily: Fonts.rounded,
+                }}
+              >
+                {isSavingAvatar ? "保存中..." : "保存"}
+              </Text>
+            </Pressable>
           </View>
         </View>
 

--- a/components/ui/avatar-image.tsx
+++ b/components/ui/avatar-image.tsx
@@ -1,0 +1,71 @@
+import { Image } from "expo-image";
+import React, { useEffect, useState } from "react";
+import { View } from "react-native";
+
+import { IconSymbol } from "@/components/ui/icon-symbol";
+
+export interface AvatarImageProps {
+  /** アバター画像のURL。null/空の場合はデフォルトアイコンを表示 */
+  avatarUrl: string | null;
+  /** 表示サイズ（幅・高さとも同じ円形） */
+  size?: number;
+  /** スケルトン用の背景色（任意） */
+  skeletonColor?: string;
+}
+
+export function AvatarImage({
+  avatarUrl,
+  size = 48,
+  skeletonColor = "rgba(200, 200, 200, 0.4)",
+}: AvatarImageProps) {
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  // URL が変わったらエラー状態をリセット
+  useEffect(() => {
+    setLoadFailed(false);
+  }, [avatarUrl]);
+
+  const hasValidUrl =
+    typeof avatarUrl === "string" && avatarUrl.trim().length > 0;
+  const showDefault = !hasValidUrl || loadFailed;
+
+  const containerStyle = {
+    width: size,
+    height: size,
+    borderRadius: 999,
+    overflow: "hidden" as const,
+    backgroundColor: "#F0FFDF",
+    alignItems: "center" as const,
+    justifyContent: "center" as const,
+  };
+
+  if (showDefault) {
+    return (
+      <View style={containerStyle}>
+        <IconSymbol name="person.fill" size={size * 0.45} color="#A8DF8E" />
+      </View>
+    );
+  }
+
+  // URL あり: スケルトンの上に Image。読み込み中はスケルトンが見え、完了で画像が表示。エラーでフォールバック
+  return (
+    <View style={containerStyle}>
+      {/* 読み込み中のスケルトン */}
+      <View
+        style={{
+          position: "absolute",
+          width: size,
+          height: size,
+          borderRadius: 999,
+          backgroundColor: skeletonColor,
+        }}
+      />
+      <Image
+        source={{ uri: avatarUrl! }}
+        style={{ width: size, height: size }}
+        onLoad={() => setLoadFailed(false)}
+        onError={() => setLoadFailed(true)}
+      />
+    </View>
+  );
+}

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -16,6 +16,10 @@ export { getTodayQuests, toggleQuestComplete } from "./quests";
 // Location API
 export { recordLocation, getMyEncounters } from "./location";
 
+// User API
+export { getMyProfile, updateMyAvatar } from "./user";
+export type { MyProfile } from "./user";
+
 // Types
 export type {
   Mood,

--- a/lib/api/location.ts
+++ b/lib/api/location.ts
@@ -44,8 +44,11 @@ export async function getMyEncounters(): Promise<EncounterWithQuests[]> {
   // 相手のユーザーIDリストを取得
   const otherUserIds = encounters.map((e) => e.other_user_id);
 
-  // 相手のユーザー情報を取得（auth.users から display_name と avatar_url）
-  const { data: users, error: usersError } = await supabase.auth.admin.listUsers();
+  // 相手のユーザー情報を public.users から取得
+  const { data: users, error: usersError } = await supabase
+    .from("users")
+    .select("uuid, display_name, avatar_url")
+    .in("uuid", otherUserIds);
 
   if (usersError) {
     console.error("ユーザー情報の取得に失敗:", usersError);
@@ -54,11 +57,11 @@ export async function getMyEncounters(): Promise<EncounterWithQuests[]> {
 
   // ユーザー情報をマップ化
   const userMap = new Map(
-    users?.users.map((user) => [
-      user.id,
+    users?.map((row) => [
+      row.uuid,
       {
-        display_name: user.user_metadata?.display_name ?? null,
-        avatar_url: user.user_metadata?.avatar_url ?? null,
+        display_name: row.display_name ?? null,
+        avatar_url: row.avatar_url ?? null,
       },
     ]) ?? []
   );

--- a/lib/api/location.ts
+++ b/lib/api/location.ts
@@ -44,8 +44,10 @@ export async function getMyEncounters(): Promise<EncounterWithQuests[]> {
   // 相手のユーザーIDリストを取得
   const otherUserIds = encounters.map((e) => e.other_user_id);
 
-  // 相手のユーザー情報を取得（auth.users から display_name と avatar_url）
-  const { data: users, error: usersError } = await supabase.auth.admin.listUsers();
+  const { data: users, error: usersError } = await supabase
+    .from("users")
+    .select("uuid, display_name, avatar_url")
+    .in("uuid", otherUserIds);
 
   if (usersError) {
     console.error("ユーザー情報の取得に失敗:", usersError);
@@ -54,11 +56,11 @@ export async function getMyEncounters(): Promise<EncounterWithQuests[]> {
 
   // ユーザー情報をマップ化
   const userMap = new Map(
-    users?.users.map((user) => [
-      user.id,
+    users?.map((user) => [
+      user.uuid,
       {
-        display_name: user.user_metadata?.display_name ?? null,
-        avatar_url: user.user_metadata?.avatar_url ?? null,
+        display_name: user.display_name ?? null,
+        avatar_url: user.avatar_url ?? null,
       },
     ]) ?? []
   );
@@ -69,6 +71,7 @@ export async function getMyEncounters(): Promise<EncounterWithQuests[]> {
   // 各すれ違いに対して、相手の今日完了したクエストを取得
   const encountersWithQuests: EncounterWithQuests[] = await Promise.all(
     encounters.map(async (encounter) => {
+      const otherUserProfile = userMap.get(encounter.other_user_id);
       // 相手の今日完了したクエストを取得
       const { data: quests, error: questsError } = await supabase
         .from("quests")
@@ -95,8 +98,10 @@ export async function getMyEncounters(): Promise<EncounterWithQuests[]> {
       return {
         id: encounter.id,
         other_user_id: encounter.other_user_id,
-        other_user_name: encounter.other_user_name ?? null,
-        other_user_avatar: encounter.other_user_avatar ?? null,
+        other_user_name:
+          encounter.other_user_name ?? otherUserProfile?.display_name ?? null,
+        other_user_avatar:
+          encounter.other_user_avatar ?? otherUserProfile?.avatar_url ?? null,
         started_at: encounter.started_at,
         last_seen_at: encounter.last_seen_at,
         ended_at: encounter.ended_at,

--- a/lib/api/user.ts
+++ b/lib/api/user.ts
@@ -1,0 +1,63 @@
+import { supabase } from "../supabase";
+
+export interface MyProfile {
+  uuid: string;
+  display_name: string | null;
+  avatar_url: string | null;
+}
+
+/**
+ * 自分のプロフィールを public.users から取得
+ */
+export async function getMyProfile(): Promise<MyProfile | null> {
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    console.error("認証情報の取得に失敗:", authError);
+    return null;
+  }
+
+  const { data, error } = await supabase
+    .from("users")
+    .select("uuid, display_name, avatar_url")
+    .eq("uuid", user.id)
+    .single();
+
+  if (error) {
+    console.error("プロフィールの取得に失敗:", error);
+    return null;
+  }
+
+  return data as MyProfile;
+}
+
+/**
+ * 自分のアバターURLを更新
+ * @param avatarUrl 新しいアバターURL。空文字の場合は NULL に更新
+ */
+export async function updateMyAvatar(avatarUrl: string): Promise<void> {
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    throw new Error("認証情報の取得に失敗しました");
+  }
+
+  const { error } = await supabase
+    .from("users")
+    .update({
+      avatar_url: avatarUrl.trim() === "" ? null : avatarUrl.trim(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("uuid", user.id);
+
+  if (error) {
+    console.error("アバターの更新に失敗:", error);
+    throw new Error(`アバターの更新に失敗: ${error.message}`);
+  }
+}

--- a/lib/location-service.ts
+++ b/lib/location-service.ts
@@ -7,7 +7,10 @@ const BACKGROUND_LOCATION_TASK = "BACKGROUND_LOCATION_TASK";
 // バックグラウンドタスクの定義
 TaskManager.defineTask(
   BACKGROUND_LOCATION_TASK,
-  async ({ data, error }: TaskManager.TaskManagerTaskBody<Location.LocationTaskEventData>) => {
+  async ({
+    data,
+    error,
+  }: TaskManager.TaskManagerTaskBody<{ locations: Location.LocationObject[] }>) => {
     if (error) {
       console.error("バックグラウンド位置情報タスクエラー:", error);
       return;


### PR DESCRIPTION
- AvatarImageコンポーネント追加（スケルトン・onErrorでデフォルトアイコン）
- lib/api/user.ts: getMyProfile, updateMyAvatar
- getMyEncountersをpublic.usersから相手情報取得に変更
- 設定画面: アバター表示・アバターURL入力・保存
- すれ違いログ: 相手カードでAvatarImageを使用