### PR TITLE
fix: 未ログイン時の位置情報送信をスキップ

### DIFF
--- a/lib/api/location.ts
+++ b/lib/api/location.ts
@@ -9,6 +9,14 @@ export async function recordLocation(
   longitude: number,
   accuracy?: number
 ): Promise<void> {
+  // ログイン状態をチェック
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    // 未ログイン時は静かにスキップ
+    console.log("未ログインのため位置情報送信をスキップ");
+    return;
+  }
+
   const { error } = await supabase.rpc("record_location", {
     p_lat: latitude,
     p_lon: longitude,

--- a/lib/location-service.ts
+++ b/lib/location-service.ts
@@ -34,7 +34,12 @@ TaskManager.defineTask(
             location.coords.accuracy ?? undefined
           );
         } catch (err) {
-          console.error("位置情報の記録に失敗:", err);
+          // 未ログイン時のスキップはエラーとして扱わない
+          if (err instanceof Error && err.message.includes("未ログイン")) {
+            console.log("バックグラウンド: 未ログインのためスキップ");
+          } else {
+            console.error("位置情報の記録に失敗:", err);
+          }
         }
       }
     }


### PR DESCRIPTION
## 概要

アプリにログインしていない状態で位置情報の送信を行うとエラーになる問題を修正しました。

## 変更内容

### lib/api/location.ts
- `recordLocation` 関数にログインチェックを追加
- 未ログイン時は静かにスキップし、エラーを発生させない

### lib/location-service.ts
- バックグラウンドタスクでのエラーハンドリングを改善
- 未ログイン時のスキップはエラーとして扱わない

## 動作確認

- [ ] 未ログイン時に位置情報送信がスキップされる
- [ ] ログイン時は通常通り位置情報が送信される
- [ ] バックグラウンドタスクでも未ログイン時にエラーが出ない