### PR TITLE
feat: ログ画面のEncounterRowカードにクエスト展開表示機能を追加

### DIFF
--- a/app/(tabs)/log.tsx
+++ b/app/(tabs)/log.tsx
@@ -290,6 +290,19 @@ export default function LogScreen() {
           <Text
             selectable
             style={{
+              fontSize: 13,
+              color: '#7DA15E',
+              textAlign: 'center',
+              fontWeight: '700',
+              fontFamily: Fonts.rounded,
+              letterSpacing: 0.2,
+            }}
+          >
+            他のユーザーが達成したクエストに挑戦してみましょう
+          </Text>
+          <Text
+            selectable
+            style={{
               fontSize: 12,
               color: '#718268',
               fontStyle: 'italic',

--- a/components/log/EncounterRow.tsx
+++ b/components/log/EncounterRow.tsx
@@ -111,39 +111,41 @@ export function EncounterRow({
                     {
                       rotate: chevronAnim.interpolate({
                         inputRange: [0, 1],
-                        outputRange: ['0deg', '90deg'],
+                        outputRange: ['0deg', '180deg'],
                       }),
                     },
                   ],
                 },
               ]}
             >
-              <IconSymbol name="chevron.right" size={18} color="#9CA986" />
+              <IconSymbol name="chevron.down" size={16} color="#9CA986" />
             </Animated.View>
           )}
         </Pressable>
-        <Pressable
-          onPress={onSendThanksStamp}
-          disabled={stampSent || sending}
-          style={({ pressed }) => [
-            styles.stampButton,
-            stampSent && styles.stampButtonSent,
-            pressed && !stampSent && styles.stampButtonPressed,
-          ]}
-        >
-          {sending ? (
-            <ActivityIndicator size="small" color={stampSent ? '#FFFFFF' : '#FFAAB8'} />
-          ) : (
-            <IconSymbol
-              name="heart.fill"
-              size={16}
-              color={stampSent ? '#FFFFFF' : '#FFAAB8'}
-            />
-          )}
-          <Text selectable style={[styles.stampText, stampSent && styles.stampTextSent]}>
+        <View style={styles.stampColumn}>
+          <Pressable
+            onPress={onSendThanksStamp}
+            disabled={stampSent || sending}
+            style={({ pressed }) => [
+              styles.stampButton,
+              stampSent && styles.stampButtonSent,
+              pressed && !stampSent && styles.stampButtonPressed,
+            ]}
+          >
+            {sending ? (
+              <ActivityIndicator size="small" color={stampSent ? '#FFFFFF' : '#FFAAB8'} />
+            ) : (
+              <IconSymbol
+                name="heart.fill"
+                size={18}
+                color={stampSent ? '#FFFFFF' : '#FFAAB8'}
+              />
+            )}
+          </Pressable>
+          <Text selectable style={[styles.stampLabel, stampSent && styles.stampLabelSent]}>
             {stampSent ? '送信済み' : 'お疲れ様'}
           </Text>
-        </Pressable>
+        </View>
       </View>
       {expanded && hasCompletedQuests && (
         <View style={styles.expandedSection}>
@@ -247,16 +249,19 @@ const styles = StyleSheet.create({
     width: 22,
     alignItems: 'flex-end',
   },
-  stampButton: {
-    flexDirection: 'row',
+  stampColumn: {
     alignItems: 'center',
-    gap: 5,
-    height: 34,
+    gap: 4,
+  },
+  stampButton: {
+    height: 40,
+    width: 40,
     borderRadius: 999,
-    backgroundColor: 'rgba(255, 170, 184, 0.10)',
+    backgroundColor: 'rgba(255, 170, 184, 0.08)',
     borderWidth: 1,
-    borderColor: 'rgba(255, 170, 184, 0.25)',
-    paddingHorizontal: 12,
+    borderColor: 'rgba(255, 170, 184, 0.20)',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   stampButtonSent: {
     backgroundColor: '#FFAAB8',
@@ -265,14 +270,14 @@ const styles = StyleSheet.create({
   stampButtonPressed: {
     backgroundColor: 'rgba(255, 170, 184, 0.20)',
   },
-  stampText: {
-    fontSize: 11,
+  stampLabel: {
+    fontSize: 10,
     fontWeight: '700',
-    color: '#FFAAB8',
+    color: '#9CA986',
     fontFamily: Fonts.rounded,
   },
-  stampTextSent: {
-    color: '#FFFFFF',
+  stampLabelSent: {
+    color: '#D87D8E',
   },
   adoptButton: {
     height: 32,

--- a/components/log/EncounterRow.tsx
+++ b/components/log/EncounterRow.tsx
@@ -1,9 +1,14 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import {
   ActivityIndicator,
+  Animated,
+  Easing,
+  LayoutAnimation,
+  Platform,
   Pressable,
   StyleSheet,
   Text,
+  UIManager,
   View,
 } from 'react-native';
 
@@ -14,6 +19,11 @@ import type { EncounterWithQuests } from '@/lib/api';
 
 import { cardContainer } from './styles';
 
+// Android で LayoutAnimation を有効化
+if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
+  UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
 export interface EncounterRowProps {
   encounter: EncounterWithQuests;
   stampSent: boolean;
@@ -21,12 +31,18 @@ export interface EncounterRowProps {
   onSendThanksStamp: () => void | Promise<void>;
 }
 
-function getQuestText(completedQuests: EncounterWithQuests['completed_quests']): string {
-  const questsToShow = completedQuests.slice(0, 3);
-  if (questsToShow.length > 0) {
-    return questsToShow.map((q) => `『${q.title}』`).join('、') + 'を達成しました';
+function getQuestSummary(completedQuests: EncounterWithQuests['completed_quests']): string {
+  if (completedQuests.length > 0) {
+    return `${completedQuests.length}件のクエストを達成`;
   }
   return '今日のクエストに挑戦中';
+}
+
+function formatCompletedAt(dateStr: string): string {
+  const date = new Date(dateStr);
+  const h = date.getHours().toString().padStart(2, '0');
+  const m = date.getMinutes().toString().padStart(2, '0');
+  return `${h}:${m}`;
 }
 
 export function EncounterRow({
@@ -35,52 +51,113 @@ export function EncounterRow({
   sending,
   onSendThanksStamp,
 }: EncounterRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const chevronAnim = useRef(new Animated.Value(0)).current;
+
   const displayName = encounter.other_user_name ?? '旅の仲間';
-  const questText = getQuestText(encounter.completed_quests);
+  const questSummary = getQuestSummary(encounter.completed_quests);
+  const hasQuests = encounter.completed_quests.length > 0;
+
+  const toggleExpand = useCallback(() => {
+    if (!hasQuests) return;
+
+    LayoutAnimation.configureNext(
+      LayoutAnimation.create(250, LayoutAnimation.Types.easeInEaseOut, LayoutAnimation.Properties.opacity)
+    );
+    setExpanded((prev) => {
+      const next = !prev;
+      Animated.timing(chevronAnim, {
+        toValue: next ? 1 : 0,
+        duration: 250,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }).start();
+      return next;
+    });
+  }, [hasQuests, chevronAnim]);
+
+  const chevronRotation = chevronAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0deg', '180deg'],
+  });
 
   return (
-    <View style={[cardContainer, styles.row]}>
-      <View style={styles.left}>
-        <AvatarImage avatarUrl={encounter.other_user_avatar} size={56} />
-        <View style={styles.info}>
-          <Text selectable style={styles.name}>
-            {displayName}
-          </Text>
-          <View style={styles.questRow}>
-            <IconSymbol name="checkmark.seal.fill" size={14} color="#7DA15E" />
-            <Text selectable numberOfLines={2} style={styles.questText}>
-              {questText}
+    <Pressable onPress={toggleExpand} style={[cardContainer, { overflow: 'hidden' }]}>
+      <View style={styles.row}>
+        <View style={styles.left}>
+          <AvatarImage avatarUrl={encounter.other_user_avatar} size={56} />
+          <View style={styles.info}>
+            <Text selectable style={styles.name}>
+              {displayName}
             </Text>
+            <View style={styles.questRow}>
+              <IconSymbol name="checkmark.seal.fill" size={14} color="#7DA15E" />
+              <Text selectable numberOfLines={1} style={styles.questText}>
+                {questSummary}
+              </Text>
+            </View>
           </View>
         </View>
-      </View>
-      <View style={styles.stampColumn}>
-        <Pressable
-          onPress={onSendThanksStamp}
-          disabled={stampSent || sending}
-          style={[
-            styles.stampButton,
-            stampSent && styles.stampButtonSent,
-          ]}
-        >
-          {sending ? (
-            <ActivityIndicator size="small" color="#FFAAB8" />
-          ) : (
-            <IconSymbol
-              name="heart.fill"
-              size={18}
-              color={stampSent ? '#D87D8E' : '#FFAAB8'}
-            />
+        <View style={styles.rightSection}>
+          <View style={styles.stampColumn}>
+            <Pressable
+              onPress={(e) => {
+                e.stopPropagation();
+                onSendThanksStamp();
+              }}
+              disabled={stampSent || sending}
+              style={[
+                styles.stampButton,
+                stampSent && styles.stampButtonSent,
+              ]}
+            >
+              {sending ? (
+                <ActivityIndicator size="small" color="#FFAAB8" />
+              ) : (
+                <IconSymbol
+                  name="heart.fill"
+                  size={18}
+                  color={stampSent ? '#D87D8E' : '#FFAAB8'}
+                />
+              )}
+            </Pressable>
+            <Text
+              selectable
+              style={[styles.stampLabel, stampSent && styles.stampLabelSent]}
+            >
+              お疲れ様
+            </Text>
+          </View>
+          {hasQuests && (
+            <Animated.View style={{ transform: [{ rotate: chevronRotation }] }}>
+              <IconSymbol name="chevron.down" size={16} color="#94A3B8" />
+            </Animated.View>
           )}
-        </Pressable>
-        <Text
-          selectable
-          style={[styles.stampLabel, stampSent && styles.stampLabelSent]}
-        >
-          お疲れ様
-        </Text>
+        </View>
       </View>
-    </View>
+
+      {expanded && hasQuests && (
+        <View style={styles.expandedSection}>
+          <View style={styles.divider} />
+          <Text style={styles.expandedTitle}>達成したクエスト</Text>
+          {encounter.completed_quests.map((quest) => (
+            <View key={quest.id} style={styles.questItem}>
+              <View style={styles.questIconBadge}>
+                <IconSymbol name="checkmark" size={12} color="#FFFFFF" />
+              </View>
+              <View style={styles.questItemInfo}>
+                <Text selectable style={styles.questItemTitle}>
+                  {quest.title}
+                </Text>
+                <Text selectable style={styles.questItemTime}>
+                  {formatCompletedAt(quest.completed_at)} に達成
+                </Text>
+              </View>
+            </View>
+          ))}
+        </View>
+      )}
+    </Pressable>
   );
 }
 
@@ -119,6 +196,10 @@ const styles = StyleSheet.create({
     flexShrink: 1,
     fontFamily: Fonts.rounded,
   },
+  rightSection: {
+    alignItems: 'center',
+    gap: 6,
+  },
   stampColumn: {
     alignItems: 'center',
     gap: 4,
@@ -142,5 +223,50 @@ const styles = StyleSheet.create({
   },
   stampLabelSent: {
     color: '#D87D8E',
+  },
+  expandedSection: {
+    paddingHorizontal: 16,
+    paddingBottom: 14,
+    gap: 10,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: '#EEF1ED',
+    marginBottom: 2,
+  },
+  expandedTitle: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: '#94A3B8',
+    letterSpacing: 1,
+    fontFamily: Fonts.rounded,
+  },
+  questItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  questIconBadge: {
+    width: 22,
+    height: 22,
+    borderRadius: 999,
+    backgroundColor: '#A8DF8E',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  questItemInfo: {
+    flex: 1,
+  },
+  questItemTitle: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#332D2E',
+    fontFamily: Fonts.rounded,
+  },
+  questItemTime: {
+    fontSize: 11,
+    color: '#94A3B8',
+    marginTop: 1,
+    fontFamily: Fonts.rounded,
   },
 });

--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -18,6 +18,7 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'chevron.down': 'expand-more',
   'person.fill': 'person',
   bell: 'notifications',
   sparkles: 'auto-awesome',


### PR DESCRIPTION
カードタップで達成クエストの詳細リストをアコーディオン表示する。
シェブロンの回転アニメーションとLayoutAnimationによるスムーズな展開を実装。