### PR TITLE
fix: 位置情報追跡におけるバックグラウンドでの位置情報インジケーターを無効にする

### DIFF
--- a/lib/location-service.ts
+++ b/lib/location-service.ts
@@ -118,7 +118,7 @@ export async function startLocationTracking(): Promise<boolean> {
         notificationColor: "#A8DF8E",
       },
       pausesUpdatesAutomatically: false, // 自動停止しない
-      showsBackgroundLocationIndicator: true, // iOS: バックグラウンド位置情報インジケータ表示
+      showsBackgroundLocationIndicator: false,
     });
 
     console.log("バックグラウンドトラッキングを開始しました");


### PR DESCRIPTION
位置情報追跡設定を調整　iOSで位置情報トラッキング中、バックグラウンドのインジケーターが表示されなくなりました。